### PR TITLE
Directory Visitor Upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,12 @@ Each Module is available as an independent downloadable package that can be quic
 
 You can import any module into your project using Gradle or maven.
 
-Here is how to implement a package using Gradle.
+Here is how to implement a package using Gradle:
+
+1. Add this to your dependencies block:
 `implementation "io.github.dk96-os.files-jvm:visitors:$package_version"`
+
+2. Add the GitHub packages maven repository.
 
 ### Visitors Module
 The concept of a File Visitor is built into the Java Standard Library.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+## Files - JVM
+A repository of tools for working with Files on the JVM (Java Virtual Machine).
+
+### Getting Started
+Each Module is available as an independent downloadable package that can be quickly imported using the GitHub Maven package registry.
+
+You can import any module into your project using Gradle or maven.
+
+Here is how to implement a package using Gradle.
+`implementation "io.github.dk96-os.files-jvm:visitors:$package_version"`
+
+### Visitors Module
+The concept of a File Visitor is built into the Java Standard Library.
+For more information on the Java Standard Library, see: [java.nio.file.FileVisitor](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/FileVisitor.html)
+
+#### Directory Visitor
+The more important class in the Visitors module is the `Directory Visitor`.
+This class requires a Path to be given in the constructor.
+The path should be a valid directory, otherwise the `isValidDirectory` flag will be false, and all methods will return empty lists.
+
+When the given Path is a valid directory, a `Simplified File Visitor` is created that collects the names of files and subdirectories that are the direct descendants (only one level deep).
+The names are stored for the lifetime of the `Directory Visitor`, and can be accessed as a list of Files, or a list of Directories.
+There are convenient methods available that can map the names into Lists of Path objects.
+
+#### Simplified File Visitor
+Within the Visitors module, you will also find a `Simplified File Visitor`.
+This is an abstract class that provides reasonable default method implementations for most of the required `FileVisitor` methods.
+It is intended to make other classes in the Visitor Module easier to read by applying the default method implementations for `FileVisitor`.
+
+

--- a/visitors/src/main/java/files/jvm/visitors/DirectoryVisitor.java
+++ b/visitors/src/main/java/files/jvm/visitors/DirectoryVisitor.java
@@ -11,9 +11,9 @@ import java.util.List;
 import java.util.Set;
 
 /** Visits Files and Directories in a single level,
- * records the files and directories that were found in a list.
+ * records the files and directories that were found.
  */
-public class SingleLevelFileVisitor {
+public class DirectoryVisitor {
 
 	/** Whether the Path given in the constructor is a valid directory.
 	 */
@@ -23,13 +23,16 @@ public class SingleLevelFileVisitor {
 
 	private final List<String> mFiles;
 
+	private final Path mPath;
+
 	/** Constructor.
 	 * @param path The path to visit.
 	 * @throws IOException Any Exception thrown while Visiting the Path.
 	 */
-	public SingleLevelFileVisitor(
+	public DirectoryVisitor(
 		final Path path
 	) throws IOException {
+		mPath = path;
 		if (!Files.isDirectory(path)) {
 			isValidDirectory = false;
 			mDirectories = null;
@@ -88,6 +91,13 @@ public class SingleLevelFileVisitor {
 		if (mFiles == null)
 			return Collections.emptyList();
 		return mFiles;
+	}
+
+	/** Obtain all files in this directory as a List of Paths.
+	 * @return A List of Paths, or an empty list.
+	 */
+	public List<Path> getFilePaths() {
+		return getFiles().stream().map(mPath::resolve).toList();
 	}
 
 }

--- a/visitors/src/main/java/files/jvm/visitors/DirectoryVisitor.java
+++ b/visitors/src/main/java/files/jvm/visitors/DirectoryVisitor.java
@@ -97,7 +97,24 @@ public class DirectoryVisitor {
 	 * @return A List of Paths, or an empty list.
 	 */
 	public List<Path> getFilePaths() {
-		return getFiles().stream().map(mPath::resolve).toList();
+		if (mFiles == null)
+			return Collections.emptyList();
+		return mFiles
+			.parallelStream()
+			.map(mPath::resolve)
+			.toList();
+	}
+
+	/** Obtain all Directories in this directory as a List of Paths.
+	 * @return A List of Paths, or an empty list.
+	 */
+	public List<Path> getDirectoryPaths() {
+		if (mDirectories == null)
+			return Collections.emptyList();
+		return mDirectories
+			.parallelStream()
+			.map(mPath::resolve)
+			.toList();
 	}
 
 }

--- a/visitors/src/test/java/files/jvm/visitors/DirectoryVisitorTest.java
+++ b/visitors/src/test/java/files/jvm/visitors/DirectoryVisitorTest.java
@@ -78,9 +78,9 @@ public final class DirectoryVisitorTest {
 	}
 
 	@Test
-	public void testConstructor_EmptyDirectory() throws IOException {
-		final Path path = testProjectDirectory.resolve("samples");
-		mInstance = new DirectoryVisitor(path);
+	public void testConstructor_SampleDirectory_OnlyContainsSingleFile() throws IOException {
+		final Path testSampleDirectory = testProjectDirectory.resolve("samples");
+		mInstance = new DirectoryVisitor(testSampleDirectory);
 		assertTrue(
 			mInstance.isValidDirectory
 		);
@@ -104,11 +104,35 @@ public final class DirectoryVisitorTest {
 	}
 
 	@Test
+	public void testGetFilePaths_InvalidDirectory_ReturnsEmptyList() throws IOException {
+		final Path invalidPath = Path.of("invalid_path");
+		mInstance = new DirectoryVisitor(invalidPath);
+		assertFalse(
+			mInstance.isValidDirectory
+		);
+		assertEquals(
+			0, mInstance.getFilePaths().size()
+		);
+	}
+
+	@Test
 	public void testGetDirectoryPaths_CorrectSize() {
 		final List<Path> pathList = mInstance.getDirectoryPaths();
 		assertEquals(
 			numberOfSubDirectories,
 			pathList.size()
+		);
+	}
+
+	@Test
+	public void testGetDirectoryPaths_InvalidPath_ReturnsEmptyList() throws IOException {
+		final Path invalidPath = Path.of("invalid_path");
+		mInstance = new DirectoryVisitor(invalidPath);
+		assertFalse(
+			mInstance.isValidDirectory
+		);
+		assertEquals(
+			0, mInstance.getDirectoryPaths().size()
 		);
 	}
 

--- a/visitors/src/test/java/files/jvm/visitors/DirectoryVisitorTest.java
+++ b/visitors/src/test/java/files/jvm/visitors/DirectoryVisitorTest.java
@@ -9,12 +9,17 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.List;
 
 /** Testing SingleLevelFileVisitor class.
  */
 public final class DirectoryVisitorTest {
 
 	private final Path testProjectDirectory = Path.of("test_directory");
+
+	private final int numberOfSubDirectories = 4;
+
+	private final int numberOfFiles = 5;
 
 	private DirectoryVisitor mInstance;
 
@@ -29,11 +34,11 @@ public final class DirectoryVisitorTest {
 			mInstance.isValidDirectory
 		);
 		assertEquals(
-			4,
+			numberOfSubDirectories,
 			mInstance.getDirectories().size()
 		);
 		assertEquals(
-			5,
+			numberOfFiles,
 			mInstance.getFiles().size()
 		);
 	}
@@ -90,10 +95,19 @@ public final class DirectoryVisitorTest {
 	}
 
 	@Test
-	public void testGetFilePaths_() {
-		final java.util.List<Path> pathList = mInstance.getFilePaths();
+	public void testGetFilePaths_CorrectSize() {
+		final List<Path> pathList = mInstance.getFilePaths();
 		assertEquals(
-			5,
+			numberOfFiles,
+			pathList.size()
+		);
+	}
+
+	@Test
+	public void testGetDirectoryPaths_CorrectSize() {
+		final List<Path> pathList = mInstance.getDirectoryPaths();
+		assertEquals(
+			numberOfSubDirectories,
 			pathList.size()
 		);
 	}

--- a/visitors/src/test/java/files/jvm/visitors/DirectoryVisitorTest.java
+++ b/visitors/src/test/java/files/jvm/visitors/DirectoryVisitorTest.java
@@ -12,15 +12,15 @@ import java.nio.file.Path;
 
 /** Testing SingleLevelFileVisitor class.
  */
-public final class SingleLevelFileVisitorTest {
+public final class DirectoryVisitorTest {
 
 	private final Path testProjectDirectory = Path.of("test_directory");
 
-	private SingleLevelFileVisitor mInstance;
+	private DirectoryVisitor mInstance;
 
 	@Before
 	public void testSetup() throws IOException {
-		mInstance = new SingleLevelFileVisitor(testProjectDirectory);
+		mInstance = new DirectoryVisitor(testProjectDirectory);
 	}
 
 	@Test
@@ -41,7 +41,7 @@ public final class SingleLevelFileVisitorTest {
 	@Test
 	public void testConstructor_FilePath_NotValidDirectory() throws IOException {
 		final Path filePath = Path.of("test_project/build.gradle");
-		mInstance = new SingleLevelFileVisitor(filePath);
+		mInstance = new DirectoryVisitor(filePath);
 		assertFalse(
 			mInstance.isValidDirectory
 		);
@@ -58,7 +58,7 @@ public final class SingleLevelFileVisitorTest {
 	@Test
 	public void testConstructor_InvalidPath_Fails() throws IOException {
 		final Path invalidPath = Path.of("invalid_path");
-		mInstance = new SingleLevelFileVisitor(invalidPath);
+		mInstance = new DirectoryVisitor(invalidPath);
 		assertFalse(
 			mInstance.isValidDirectory
 		);
@@ -75,7 +75,7 @@ public final class SingleLevelFileVisitorTest {
 	@Test
 	public void testConstructor_EmptyDirectory() throws IOException {
 		final Path path = testProjectDirectory.resolve("samples");
-		mInstance = new SingleLevelFileVisitor(path);
+		mInstance = new DirectoryVisitor(path);
 		assertTrue(
 			mInstance.isValidDirectory
 		);
@@ -86,6 +86,15 @@ public final class SingleLevelFileVisitorTest {
 		assertEquals(
 			1,
 			mInstance.getFiles().size()
+		);
+	}
+
+	@Test
+	public void testGetFilePaths_() {
+		final java.util.List<Path> pathList = mInstance.getFilePaths();
+		assertEquals(
+			5,
+			pathList.size()
 		);
 	}
 


### PR DESCRIPTION
First, rename the class `SingleLevelFileVisitor` to `DirectoryVisitor`. This new name is simpler, easier to read, and makes it easier to understand.

While it technically uses a FileVisitor that only visits a single level in a file system tree, it may also be thought of as a FileVisitor that only visits a single Directory.

Second, enhance the utility of the class by adding methods that return Path objects. This helps the user who wants to access the Files that were found in the directory, or the user who wants to visit one of the subdirectories. Rather than the user having to maintain reference to the directory Path and resolving sub-paths themselves, these methods can use the Path that was provided in the constructor.

Third, add a README file to the repository.