### PR TITLE
DirectoryVisitor Streams Methods and Nullable Annotations

### DIFF
--- a/visitors/src/main/java/files/jvm/visitors/DirectoryVisitor.java
+++ b/visitors/src/main/java/files/jvm/visitors/DirectoryVisitor.java
@@ -1,5 +1,6 @@
 package files.jvm.visitors;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
@@ -8,7 +9,12 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Stream;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /** Visits Files and Directories in a single level,
  * records the files and directories that were found.
@@ -19,18 +25,21 @@ public class DirectoryVisitor {
 	 */
 	public final boolean isValidDirectory;
 
-	private final List<String> mDirectories;
+	@Nullable
+	protected final List<String> mDirectories;
 
-	private final List<String> mFiles;
+	@Nullable
+	protected final List<String> mFiles;
 
-	private final Path mPath;
+	@Nonnull
+	protected final Path mPath;
 
 	/** Constructor.
 	 * @param path The path to visit.
 	 * @throws IOException Any Exception thrown while Visiting the Path.
 	 */
 	public DirectoryVisitor(
-		final Path path
+		@Nonnull final Path path
 	) throws IOException {
 		mPath = path;
 		if (!Files.isDirectory(path)) {
@@ -78,24 +87,27 @@ public class DirectoryVisitor {
 	/** Obtain the directory names found at this Path.
 	 * @return The List of directories, or an empty List.
 	 */
+	@Nonnull
 	public List<String> getDirectories() {
-		if (mDirectories == null)
-			return Collections.emptyList();
-		return mDirectories;
+		return Objects.requireNonNullElse(
+			mDirectories, Collections.emptyList()
+		);
 	}
 
 	/** Obtain the File names found at this Path.
 	 * @return The List of File Names, or an empty List.
 	 */
+	@Nonnull
 	public List<String> getFiles() {
-		if (mFiles == null)
-			return Collections.emptyList();
-		return mFiles;
+		return Objects.requireNonNullElse(
+			mFiles, Collections.emptyList()
+		);
 	}
 
 	/** Obtain all files in this directory as a List of Paths.
 	 * @return A List of Paths, or an empty list.
 	 */
+	@Nonnull
 	public List<Path> getFilePaths() {
 		if (mFiles == null)
 			return Collections.emptyList();
@@ -105,9 +117,23 @@ public class DirectoryVisitor {
 			.toList();
 	}
 
+	/** Obtain a Stream of all Files in the Directory.
+	 * @return A Stream of File objects.
+	 */
+	@Nonnull
+	public Stream<File> getFileStream() {
+		if (mFiles == null)
+			return Stream.empty();
+		return mFiles
+			.parallelStream()
+			.map(mPath::resolve)
+			.map(Path::toFile);
+	}
+
 	/** Obtain all Directories in this directory as a List of Paths.
 	 * @return A List of Paths, or an empty list.
 	 */
+	@Nonnull
 	public List<Path> getDirectoryPaths() {
 		if (mDirectories == null)
 			return Collections.emptyList();
@@ -115,6 +141,18 @@ public class DirectoryVisitor {
 			.parallelStream()
 			.map(mPath::resolve)
 			.toList();
+	}
+
+	/** Obtain all Directories in this directory as a Stream of Paths.
+	 * @return A Stream of Paths.
+	 */
+	@Nonnull
+	public Stream<Path> getDirectoryPathStream() {
+		if (mDirectories == null)
+			return Stream.empty();
+		return mDirectories
+			.parallelStream()
+			.map(mPath::resolve);
 	}
 
 }

--- a/visitors/src/test/java/files/jvm/visitors/DirectoryVisitorTest.java
+++ b/visitors/src/test/java/files/jvm/visitors/DirectoryVisitorTest.java
@@ -116,6 +116,15 @@ public final class DirectoryVisitorTest {
 	}
 
 	@Test
+	public void testGetFileStream_() {
+		final var pathList = mInstance.getFileStream();
+		assertEquals(
+			numberOfFiles,
+			pathList.toList().size()
+		);
+	}
+
+	@Test
 	public void testGetDirectoryPaths_CorrectSize() {
 		final List<Path> pathList = mInstance.getDirectoryPaths();
 		assertEquals(
@@ -133,6 +142,15 @@ public final class DirectoryVisitorTest {
 		);
 		assertEquals(
 			0, mInstance.getDirectoryPaths().size()
+		);
+	}
+
+	@Test
+	public void testGetDirectoryPathStream_() {
+		final var pathList = mInstance.getDirectoryPathStream();
+		assertEquals(
+			numberOfSubDirectories,
+			pathList.toList().size()
 		);
 	}
 


### PR DESCRIPTION
## Enhancements

### Visitors Module
1. Add DirectoryVisitor Streams Methods
2. Annotate DirectoryVisitor Type Nullability
3. Increase Visibility of DirectoryVisitor Members from private to protected
4. Replace `if-null-checks` with `requireNonNullElse`

#### New Streams Methods
- Get File Stream : Stream<File>
- Get Directory Path Stream : Stream<Path>